### PR TITLE
Add dToken pools, make processing more reliable

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
   "usdThreshold": 50000,
   "watchIntervalInSeconds": 30,
+  "numberOfSwapsToFetch": 100,
   "twitter": {
     "apiKey": "",
     "apiSecretKey": "",

--- a/config/development.json
+++ b/config/development.json
@@ -1,4 +1,5 @@
 {
-  "usdThreshold": 10,
-  "watchIntervalInSeconds": 5
+  "usdThreshold": 50000,
+  "watchIntervalInSeconds": 5,
+  "numberOfSwapsToFetch": 2
 }

--- a/config/test.json
+++ b/config/test.json
@@ -1,0 +1,4 @@
+{
+  "usdThreshold": 50000,
+  "watchIntervalInSeconds": 1
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,6 +1,6 @@
 import config from 'config';
 
-import { getLastProcessedBlock, getTweetIdByTxid, storeProcessedTxid, updateLastProcessed } from "../src/store/database";
+import { getTweetIdByTxid, storeProcessedTxid, updateLastProcessed } from "../src/store/database";
 import { dexSwapIsOverThreshold } from "./process/dexSwapIsOverThreshold";
 import { extractDexSwaps } from "./process/extractSwaps";
 import { getUsdCoinPriceForDfi } from "./query/coinPrices";
@@ -10,9 +10,7 @@ import { tweet } from './twitter/tweet';
 const watchIntervalInSeconds: number = config.get('watchIntervalInSeconds');
 
 const whaleWatch = async (): Promise<void> => {
-  const lastProcessedBlock = await getLastProcessedBlock();
-
-  const swaps = await extractDexSwaps(lastProcessedBlock);
+  const swaps = await extractDexSwaps();
 
   if (swaps.length === 0) {
     console.log('No new swaps');
@@ -28,7 +26,7 @@ const whaleWatch = async (): Promise<void> => {
 
     if (!usdValue) {
       // swap below noteworthy threshold
-      console.log('Swap below noteworthy threshold', txid);
+      // console.log('Swap below noteworthy threshold', txid);
       await updateLastProcessed(swap.blockHeight, txid);
       return;
     }
@@ -36,6 +34,7 @@ const whaleWatch = async (): Promise<void> => {
     const tweetIdFromTxid = await getTweetIdByTxid(txid);
     if (tweetIdFromTxid) {
       // txid already processed via tweet
+      console.log('Swap already processed via tweet', txid);
       await updateLastProcessed(blockHeight, txid);
       return;
     }

--- a/src/process/__tests__/extractSwaps.test.ts
+++ b/src/process/__tests__/extractSwaps.test.ts
@@ -3,7 +3,7 @@ import { extractDexSwaps } from "../extractSwaps";
 jest.mock('../../query/dfcApi');
 
 test.skip('extract DEX swaps from API, excluding processed blocks', async () => {
-  const res = await extractDexSwaps(998530);
+  const res = await extractDexSwaps();
 
   expect(res).toStrictEqual([
       {

--- a/src/process/dexSwapIsOverThreshold.ts
+++ b/src/process/dexSwapIsOverThreshold.ts
@@ -5,25 +5,29 @@ import { Swap } from "../types/Swap";
 const usdThreshold: number = config.get('usdThreshold');
 
 const dexSwapIsOverThreshold = async (swap: Swap, dfiUsdPrice: number): Promise<BigNumber | null> => {
-  const dfiAmount = getDfiAmount(swap);
-
-  const usdValue = dfiAmount * dfiUsdPrice;
+  const usdValue = getUsdValue(swap, dfiUsdPrice);
 
   if (usdValue && usdValue >= usdThreshold) {
-    return new BigNumber(usdValue).decimalPlaces(0, BigNumber.ROUND_DOWN);
+    return new BigNumber(usdValue).decimalPlaces(2, BigNumber.ROUND_DOWN);
   }
 
   return null;
 }
 
-const getDfiAmount = (swap: Swap) => {
-  if (swap.baseTokenSymbol === 'DFI') {
+const getUsdValue = (swap: Swap, dfiUsdPrice: number) => {
+  if (swap.baseTokenSymbol === 'DUSD') {
     return swap.baseTokenAmount;
   }
-  if (swap.quoteTokenSymbol === 'DFI') {
+  if (swap.quoteTokenSymbol === 'DUSD') {
     return swap.quoteTokenAmount;
   }
-  throw new Error(`None of the symbols are DFI: ${JSON.stringify(swap)}`);
+  if (swap.baseTokenSymbol === 'DFI') {
+    return swap.baseTokenAmount * dfiUsdPrice;
+  }
+  if (swap.quoteTokenSymbol === 'DFI') {
+    return swap.quoteTokenAmount * dfiUsdPrice;
+  }
+  throw new Error(`None of the symbols are DFI or DUSD: ${JSON.stringify(swap)}`);
 }
 
 export {

--- a/src/process/extractSwaps.ts
+++ b/src/process/extractSwaps.ts
@@ -2,23 +2,39 @@ import { Swap } from "../types/Swap";
 import { getLatestSwapTransactions } from "../query/dfcApi";
 
 const POOL_IDS = [
-  '4', // ETH
-  '5', // BTC
-  '6', // USDT
-  '8', // DOGE
-  '10', // LTC
-  '12', // BCH
+  '4', // ETH-DFI
+  '5', // BTC-DFI
+  '6', // USDT-DFI
+  '8', // DOGE-DFI
+  '10', // LTC-DFI
+  '12', // BCH-DFI
+  '14', // USDT-DFI
+  '17', // DUSD-DFI
+  '18', // TSLA-DUSD
+  '25', // GME-DUSD
+  '32', // GOOGL-DUSD
+  '33', // BABA-DUSD
+  '35', // PLTR-DUSD
+  '36', // AAPL-DUSD
+  '38', // SPY-DUSD
+  '39', // QQQ-DUSD
+  '40', // PDBC-DUSD
+  '41', // VNQ-DUSD
+  '42', // ARKK-DUSD
+  '43', // GLD-DUSD
+  '44', // URTH-DUSD
+  '45', // TLT-DUSD
+  '46', // SLV-DUSD
 ];
 
-const extractDexSwaps = async (lastProcessedBlock?: number): Promise<Swap[]> => {
+const extractDexSwaps = async (): Promise<Swap[]> => {
 
   const swaps = await Promise.all(POOL_IDS.map(id => {
     return getLatestSwapTransactions(id, '100');
   }));
 
   const sortedSwaps = new Array<Swap>().concat(...swaps).sort((a, b) => a.blockHeight - b.blockHeight);
-  const swapsAfterLastProcessed = lastProcessedBlock ? sortedSwaps.filter(s => s.blockHeight > lastProcessedBlock) : sortedSwaps;
-  return swapsAfterLastProcessed
+  return sortedSwaps;
 }
 
 export {

--- a/src/twitter/tweet.ts
+++ b/src/twitter/tweet.ts
@@ -26,7 +26,7 @@ const tweet = async (status: string): Promise<string> => {
     return response.id_str;
   }
 
-  return '';
+  return status;
 }
 
 


### PR DESCRIPTION
Watching new pools:
- DUSD-DFI
- TSLA-DUSD
- GME-DUSD
- GOOGL-DUSD
- BABA-DUSD
- PLTR-DUSD
- AAPL-DUSD
- SPY-DUSD
- QQQ-DUSD
- PDBC-DUSD
- VNQ-DUSD
- ARKK-DUSD
- GLD-DUSD
- URTH-DUSD
- TLT-DUSD
- SLV-DUSD